### PR TITLE
add work-in-progress overlay

### DIFF
--- a/spaceship/static/wip-overlay.css
+++ b/spaceship/static/wip-overlay.css
@@ -1,78 +1,10 @@
-#overlay-background {
-  background-color: rgb(0, 0, 0);
-  display: none;
-  left: 0px;
-  top: 0px;
-  height: 100%;
-  margin: 0px;
-  opacity: 0.75;
-  position: fixed;
-  width: 100%;
-  z-index: 999998;
-}
-.overlay-container {
-    box-sizing: border-box;
-    display: none;
-    margin: 0px auto;
-    padding: 15px 15px 15px 15px;
-    max-width: calc(100% - 30px);
-    position: fixed;
-    opacity: 1;
-    z-index: 999999;
-    left: 0px;
-    right: 0px;
-    width: 678px;
-    height: calc(100% - 20px);
-    top: 50%;
-    transform: translateY(-50%);
-    max-height: 510px;
-    background: rgba(255,255,255, 0.95);
-    h1,h2,h3,p,li,a {
-      font-family: "Circular Std", "Lato", sans-serif;
-      -webkit-font-smoothing: antialiased;
-      -moz-osx-font-smoothing: grayscale;
-    }
-    @media screen and (max-width: $screen-xs-min) {
-      margin-top: 0;
-      padding-right: 7px;
-      padding-left: 7px;
-    }
-  }
-  #overlay .overlay-title {
-    font-family: 'Circular Std', 'Lato', sans-serif;
-    font-weight: bold;
-    font-size: 36px;
-    text-align: center;
-  }
-  #overlay .overlay-desc {
-    font-family: 'Circular Std', 'Lato', sans-serif;
-    font-weight: normal;
-    font-size: 18px;
-  }
-  #overlay .icon img{
-    width: 150px;
+  .icon img {
+    width: 50px;
     height: auto;
-    margin-bottom: 20px;
+    margin-top: 10px;
+    margin-right: 5px;
   }
-  #overlay .close-button {
-    text-align: center !important;
-  }
-  #overlay #close-overlay {
-    color: #FFF;
-    background-color: #ed604e;
-    font-family: "Circular Std", "Lato", sans-serif;
-    font-weight: bold;
-    font-size: 1.4em;
-    padding: 12px 20px !important;
-    border-radius: 4px;
-    transition: 0.2s ease-in-out all;
-    -moz-box-shadow: 0 2px 4px 0 rgba(0,0,0,0.22);
-    -webkit-box-shadow: 0 2px 4px 0 rgba(0,0,0,0.22);
-    box-shadow: 0 2px 4px 0 rgba(0,0,0,0.22);
-    display: inline-block;
-    margin: 5px auto;
-  }
-  #overlay #close-overlay:hover {
-    background-color: #007bff;
-    text-decoration: none;
+
+  h3.modal-title {
+    margin-top: 12px;
   }

--- a/spaceship/static/wip-overlay.css
+++ b/spaceship/static/wip-overlay.css
@@ -1,0 +1,78 @@
+#overlay-background {
+  background-color: rgb(0, 0, 0);
+  display: block;
+  left: 0px;
+  top: 0px;
+  height: 100%;
+  margin: 0px;
+  opacity: 0.75;
+  position: fixed;
+  width: 100%;
+  z-index: 999998;
+}
+.overlay-container {
+    box-sizing: border-box;
+    display: block;
+    margin: 0px auto;
+    padding: 15px 15px 15px 15px;
+    max-width: calc(100% - 30px);
+    position: fixed;
+    opacity: 1;
+    z-index: 999999;
+    left: 0px;
+    right: 0px;
+    width: 678px;
+    height: calc(100% - 20px);
+    top: 50%;
+    transform: translateY(-50%);
+    max-height: 500px;
+    background: rgba(255,255,255, 0.95);
+    h1,h2,h3,p,li,a {
+      font-family: "Circular Std", "Lato", sans-serif;
+      -webkit-font-smoothing: antialiased;
+      -moz-osx-font-smoothing: grayscale;
+    }
+    @media screen and (max-width: $screen-xs-min) {
+      margin-top: 0;
+      padding-right: 7px;
+      padding-left: 7px;
+    }
+  }
+  #overlay .overlay-title {
+    font-family: 'Circular Std', 'Lato', sans-serif;
+    font-weight: bold;
+    font-size: 36px;
+    text-align: center;
+  }
+  #overlay .overlay-desc {
+    font-family: 'Circular Std', 'Lato', sans-serif;
+    font-weight: normal;
+    font-size: 18px;
+  }
+  #overlay .icon img{
+    width: 150px;
+    height: auto;
+    margin-bottom: 20px;
+  }
+  #overlay .close-button {
+    text-align: center !important;
+  }
+  #overlay #close-overlay {
+    color: #FFF;
+    background-color: #ed604e;
+    font-family: "Circular Std", "Lato", sans-serif;
+    font-weight: bold;
+    font-size: 1.4em;
+    padding: 12px 20px !important;
+    border-radius: 4px;
+    transition: 0.2s ease-in-out all;
+    -moz-box-shadow: 0 2px 4px 0 rgba(0,0,0,0.22);
+    -webkit-box-shadow: 0 2px 4px 0 rgba(0,0,0,0.22);
+    box-shadow: 0 2px 4px 0 rgba(0,0,0,0.22);
+    display: inline-block;
+    margin: 5px auto;
+  }
+  #overlay #close-overlay:hover {
+    background-color: #007bff;
+    text-decoration: none;
+  }

--- a/spaceship/static/wip-overlay.css
+++ b/spaceship/static/wip-overlay.css
@@ -1,6 +1,6 @@
 #overlay-background {
   background-color: rgb(0, 0, 0);
-  display: block;
+  display: none;
   left: 0px;
   top: 0px;
   height: 100%;
@@ -12,7 +12,7 @@
 }
 .overlay-container {
     box-sizing: border-box;
-    display: block;
+    display: none;
     margin: 0px auto;
     padding: 15px 15px 15px 15px;
     max-width: calc(100% - 30px);
@@ -25,7 +25,7 @@
     height: calc(100% - 20px);
     top: 50%;
     transform: translateY(-50%);
-    max-height: 500px;
+    max-height: 510px;
     background: rgba(255,255,255, 0.95);
     h1,h2,h3,p,li,a {
       font-family: "Circular Std", "Lato", sans-serif;

--- a/spaceship/static/wip-overlay.js
+++ b/spaceship/static/wip-overlay.js
@@ -1,10 +1,4 @@
 (function() {
-  var closeOverlay = (evnt) => {
-    document.getElementById('overlay-background').style.display = 'none';
-    document.getElementById('overlay').style.display = 'none';
-    evnt.preventDefault();
-    evnt.stopPropagation();
-  };
   // cookie functions based on https://stackoverflow.com/questions/14573223/set-cookie-and-get-cookie-with-javascript#24103596
   var setCookie = (name, value, days) => {
     var expires = '';
@@ -27,18 +21,9 @@
   };
   window.addEventListener('load', () => {
     if (getCookie('spaceshipearth_display_wip') != 'false') {
-      document.getElementById('overlay-background').style.display = 'block';
-      document.getElementById('overlay').style.display = 'block';
-      const elmts = document.getElementsByClassName('close-overlay');
-      const handleclicks = Array.prototype.filter.call(elmts, (elmt) => {
-        elmt.addEventListener('click', closeOverlay, false);
+      $('#wipOverlay').modal({
+        keyboard: true
       });
-      document.addEventListener('keydown', (e) => {
-        // close overlay when escape key is pressed
-        if (e.keyCode == 27) {
-          closeOverlay(e);
-        }
-      }, false);
       setCookie('spaceshipearth_display_wip', 'false', 90);
     }
   }, false);

--- a/spaceship/static/wip-overlay.js
+++ b/spaceship/static/wip-overlay.js
@@ -1,30 +1,10 @@
 (function() {
-  // cookie functions based on https://stackoverflow.com/questions/14573223/set-cookie-and-get-cookie-with-javascript#24103596
-  var setCookie = (name, value, days) => {
-    var expires = '';
-    if (days) {
-        var date = new Date();
-        date.setTime(date.getTime() + (days*24*60*60*1000));
-        expires = '; expires=' + date.toUTCString();
-    }
-    document.cookie = name + '=' + (value || '')  + expires + '; path=/';
-  };
-  var getCookie = (name) => {
-    var nameEQ = name + '=';
-    var ca = document.cookie.split(';');
-    for(var i=0; i < ca.length; i++) {
-        var c = ca[i];
-        while (c.charAt(0) == ' ') c = c.substring(1, c.length);
-        if (c.indexOf(nameEQ) == 0) return c.substring(nameEQ.length, c.length);
-    }
-    return null;
-  };
   window.addEventListener('load', () => {
-    if (getCookie('spaceshipearth_display_wip') != 'false') {
+    if (Cookies.get('spaceshipearth_display_wip') != 'false') {
       $('#wipOverlay').modal({
         keyboard: true
       });
-      setCookie('spaceshipearth_display_wip', 'false', 90);
+      Cookies.set('spaceshipearth_display_wip', 'false', { expires: 90, path: '' });
     }
   }, false);
 })();

--- a/spaceship/static/wip-overlay.js
+++ b/spaceship/static/wip-overlay.js
@@ -1,10 +1,8 @@
-(function() {
-  window.addEventListener('load', () => {
-    if (Cookies.get('spaceshipearth_display_wip') != 'false') {
-      $('#wipOverlay').modal({
-        keyboard: true
-      });
-      Cookies.set('spaceshipearth_display_wip', 'false', { expires: 90, path: '' });
-    }
-  }, false);
-})();
+$(window).on('load', function() {
+  if (Cookies.get('spaceshipearth_display_wip') != 'false') {
+    $('#wipOverlay').modal({
+      keyboard: true
+    });
+    Cookies.set('spaceshipearth_display_wip', 'false', { expires: 90, path: '' });
+  }
+});

--- a/spaceship/static/wip-overlay.js
+++ b/spaceship/static/wip-overlay.js
@@ -1,20 +1,45 @@
 (function() {
-  var closeOverlay = (event) => {
+  var closeOverlay = (evnt) => {
     document.getElementById('overlay-background').style.display = 'none';
     document.getElementById('overlay').style.display = 'none';
-    event.preventDefault();
-    event.stopPropagation();
+    evnt.preventDefault();
+    evnt.stopPropagation();
+  };
+  // cookie functions based on https://stackoverflow.com/questions/14573223/set-cookie-and-get-cookie-with-javascript#24103596
+  var setCookie = (name, value, days) => {
+    var expires = '';
+    if (days) {
+        var date = new Date();
+        date.setTime(date.getTime() + (days*24*60*60*1000));
+        expires = '; expires=' + date.toUTCString();
+    }
+    document.cookie = name + '=' + (value || '')  + expires + '; path=/';
+  };
+  var getCookie = (name) => {
+    var nameEQ = name + '=';
+    var ca = document.cookie.split(';');
+    for(var i=0; i < ca.length; i++) {
+        var c = ca[i];
+        while (c.charAt(0) == ' ') c = c.substring(1, c.length);
+        if (c.indexOf(nameEQ) == 0) return c.substring(nameEQ.length, c.length);
+    }
+    return null;
   };
   window.addEventListener('load', () => {
-    const elmts = document.getElementsByClassName('close-overlay');
-    const handleclicks = Array.prototype.filter.call(elmts, (elmt) => {
-      elmt.addEventListener('click', closeOverlay, false);
-    });
-    document.addEventListener('keydown', (e) => {
-      // close overlay when escape key is pressed
-      if (e.keyCode == 27) {
-        closeOverlay(e);
-      }
-    }, false);
+    if (getCookie('displayWIP') != 'false') {
+      document.getElementById('overlay-background').style.display = 'block';
+      document.getElementById('overlay').style.display = 'block';
+      const elmts = document.getElementsByClassName('close-overlay');
+      const handleclicks = Array.prototype.filter.call(elmts, (elmt) => {
+        elmt.addEventListener('click', closeOverlay, false);
+      });
+      document.addEventListener('keydown', (e) => {
+        // close overlay when escape key is pressed
+        if (e.keyCode == 27) {
+          closeOverlay(e);
+        }
+      }, false);
+      setCookie('displayWIP', 'false', 90);
+    }
   }, false);
 })();

--- a/spaceship/static/wip-overlay.js
+++ b/spaceship/static/wip-overlay.js
@@ -1,0 +1,20 @@
+(function() {
+  var closeOverlay = (event) => {
+    document.getElementById('overlay-background').style.display = 'none';
+    document.getElementById('overlay').style.display = 'none';
+    event.preventDefault();
+    event.stopPropagation();
+  };
+  window.addEventListener('load', () => {
+    const elmts = document.getElementsByClassName('close-overlay');
+    const handleclicks = Array.prototype.filter.call(elmts, (elmt) => {
+      elmt.addEventListener('click', closeOverlay, false);
+    });
+    document.addEventListener('keydown', (e) => {
+      // close overlay when escape key is pressed
+      if (e.keyCode == 27) {
+        closeOverlay(e);
+      }
+    }, false);
+  }, false);
+})();

--- a/spaceship/static/wip-overlay.js
+++ b/spaceship/static/wip-overlay.js
@@ -26,7 +26,7 @@
     return null;
   };
   window.addEventListener('load', () => {
-    if (getCookie('displayWIP') != 'false') {
+    if (getCookie('spaceshipearth_display_wip') != 'false') {
       document.getElementById('overlay-background').style.display = 'block';
       document.getElementById('overlay').style.display = 'block';
       const elmts = document.getElementsByClassName('close-overlay');
@@ -39,7 +39,7 @@
           closeOverlay(e);
         }
       }, false);
-      setCookie('displayWIP', 'false', 90);
+      setCookie('spaceshipearth_display_wip', 'false', 90);
     }
   }, false);
 })();

--- a/spaceship/templates/base.html
+++ b/spaceship/templates/base.html
@@ -27,6 +27,7 @@
   <link rel="stylesheet" href="/static/bootstrap.min.css">
   {% endif %}
   <link rel="stylesheet" type="text/css" href="/static/spaceship.css">
+  <link rel="stylesheet" type="text/css" href="/static/wip-overlay.css">
 </head>
 
 <body>
@@ -140,6 +141,7 @@ $.ajaxSetup({
 
 <script src="/static/prevent-invalid-form-submit.js"></script>
 <script src="/static/edit.js"></script>
+<script src="/static/wip-overlay.js"></script>
 
 {% endblock %}
 

--- a/spaceship/templates/base.html
+++ b/spaceship/templates/base.html
@@ -122,6 +122,9 @@
 
 <!-- moment -->
 <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.24.0/moment.min.js" integrity="sha384-fYxN7HsDOBRo1wT/NSZ0LkoNlcXvpDpFy6WzB42LxuKAX7sBwgo7vuins+E1HCaw" crossorigin="anonymous"></script>
+<!-- js-cookie -->
+<script src="https://cdnjs.cloudflare.com/ajax/libs/js-cookie/2.2.0/js.cookie.min.js" integrity="sha384-ujpAYcyxFaJsZN5668lLgOpEH8vtWrbOq8fvj+WZ2kD71LJwGa/9QP/suPPF1hTI" crossorigin="anonymous"></script>
+
 {% else %}
 <script src="/static/jquery-3.2.1.js"></script>
 <script src="/static/bootstrap.bundle.min.js"></script>

--- a/spaceship/templates/index.html
+++ b/spaceship/templates/index.html
@@ -3,6 +3,7 @@
 {% block title %}Home - {{ super() }}{% endblock %}
 
 {% block content %}
+{% include 'wip-overlay.html' %}
 {% include 'banner.html' %}
 
 <section class="splash-stats row justify-content-md-center">

--- a/spaceship/templates/wip-overlay.html
+++ b/spaceship/templates/wip-overlay.html
@@ -4,9 +4,7 @@
   <p class="overlay-title">Commence primary ignition...</p>
   <p class="overlay-desc">Thanks for checking out our very first version of <b>Spaceship Earth</b>! We're in the process of building a community planning tool for groups of friends who want to do something about climate change.</p>
   <p class="overlay-desc">You may notice a few things are rough around the edges and many aspects of the site will certainly change in the future. We'd love your <a href="/contact">help and feedback</a>!</p>
-  <div class="button-area">
-    <div class="close-button">
-      <a id="close-overlay" class="close-overlay" href="#">Check it out</a>
-    </div>
+  <div class="close-button">
+    <a id="close-overlay" class="close-overlay" href="#">Check it out</a>
   </div>
 </div>

--- a/spaceship/templates/wip-overlay.html
+++ b/spaceship/templates/wip-overlay.html
@@ -1,10 +1,22 @@
-<div id="overlay-background" class="close-overlay"></div>
-<div id="overlay" class="overlay-container">
-  <div class="icon"><img src="/static/sship-152.png"></div>
-  <p class="overlay-title">Commence primary ignition...</p>
-  <p class="overlay-desc">Thanks for checking out our very first version of <b>Spaceship Earth</b>! We're in the process of building a community planning tool for groups of friends who want to do something about climate change.</p>
-  <p class="overlay-desc">You may notice a few things are rough around the edges and many aspects of the site will certainly change in the future. We'd love your <a href="/contact">help and feedback</a>!</p>
-  <div class="close-button">
-    <a id="close-overlay" class="close-overlay" href="#">Check it out</a>
+<div class="modal fade" id="wipOverlay" tabindex="-1" role="dialog" aria-labelledby="wipOverlayTitle" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <div class="icon"><img src="/static/sship-152.png"></div>
+        <h3 class="modal-title text-center" id="wipOverlayTitle">Commence primary ignition...</h3>
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+      <div class="modal-body">
+        <p class="overlay-desc">Thanks for checking out our very first version of <b>Spaceship Earth</b>! We're in the process of building a community planning tool for groups of friends who want to do something about climate change.</p>
+        <p class="overlay-desc">You may notice a few things are rough around the edges and many aspects of the site will certainly change in the future. We'd love your <a href="/contact">help and feedback</a>!</p>
+      </div>
+      <div class="modal-footer">
+        <div class="col text-center">
+          <button type="button" class="btn btn-secondary btn-lg" data-dismiss="modal">Check it out</button>
+        </div>
+      </div>
+    </div>
   </div>
 </div>

--- a/spaceship/templates/wip-overlay.html
+++ b/spaceship/templates/wip-overlay.html
@@ -9,8 +9,8 @@
         </button>
       </div>
       <div class="modal-body">
-        <p class="overlay-desc">Thanks for checking out our very first version of <b>Spaceship Earth</b>! We're in the process of building a community planning tool for groups of friends who want to do something about climate change.</p>
-        <p class="overlay-desc">You may notice a few things are rough around the edges and many aspects of the site will certainly change in the future. We'd love your <a href="/contact">help and feedback</a>!</p>
+        <p>Thanks for checking out our very first version of <b>Spaceship Earth</b>! We're in the process of building a community planning tool for groups of friends who want to do something about climate change.</p>
+        <p>You may notice a few things are rough around the edges and many aspects of the site will certainly change in the future. We'd love your <a href="/contact">help and feedback</a>!</p>
       </div>
       <div class="modal-footer">
         <div class="col text-center">

--- a/spaceship/templates/wip-overlay.html
+++ b/spaceship/templates/wip-overlay.html
@@ -1,0 +1,12 @@
+<div id="overlay-background" class="close-overlay"></div>
+<div id="overlay" class="overlay-container">
+  <div class="icon"><img src="/static/sship-152.png"></div>
+  <p class="overlay-title">Commence primary ignition...</p>
+  <p class="overlay-desc">Thanks for checking out our very first version of <b>Spaceship Earth</b>! We're in the process of building a community planning tool for groups of friends who want to do something about climate change.</p>
+  <p class="overlay-desc">You may notice a few things are rough around the edges and many aspects of the site will certainly change in the future. We'd love your <a href="/contact">help and feedback</a>!</p>
+  <div class="button-area">
+    <div class="close-button">
+      <a id="close-overlay" class="close-overlay" href="#">Check it out</a>
+    </div>
+  </div>
+</div>

--- a/spaceship/templates/wip-overlay.html
+++ b/spaceship/templates/wip-overlay.html
@@ -14,7 +14,7 @@
       </div>
       <div class="modal-footer">
         <div class="col text-center">
-          <button type="button" class="btn btn-secondary btn-lg" data-dismiss="modal">Check it out</button>
+          <button type="button" class="btn btn-primary btn-lg" data-dismiss="modal">Check it out</button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Fixes #31 

This adds a one-time overlay explaining that Spaceship Earth is still highly in progress. It sets a cookie to know a user has already seen the overlay and won't show it again for 90 days.

If someone's browser has javascript disabled, no work-in-progress overlay will be displayed which I consider degrading gracefully.

CSS is not my best friend so I'd love any tweaking to make this look nicer and keep the "Check it out" div from floating off the end of the box when the window size shrinks. I'm sure this looks terrible on mobile but haven't set up an emulator to test it 😊