### PR TITLE
Basic support for editable missions

### DIFF
--- a/migrations/0002_add_name_to_user.py
+++ b/migrations/0002_add_name_to_user.py
@@ -2,10 +2,8 @@
 add name to user
 date created: 2019-03-29 02:33:24.496832
 """
-from peewee import CharField
-
 def upgrade(migrator):
-    migrator.add_column('user', 'name', CharField, max_length=255, default='')
+    migrator.add_column('user', 'name', 'char', max_length=255, default='')
 
 def downgrade(migrator):
     migrator.drop_column('user', 'name')

--- a/migrations/0012_add_description_to_team.py
+++ b/migrations/0012_add_description_to_team.py
@@ -2,10 +2,8 @@
 add description to team
 date created: 2019-04-26 06:27:46.338009
 """
-from peewee import TextField
-
 def upgrade(migrator):
-    migrator.add_column('team', 'description', TextField, default='Best. Crew. Ever.')
+    migrator.add_column('team', 'description', 'text', default='Best. Crew. Ever.')
 
 def downgrade(migrator):
     migrator.drop_column('team', 'description')

--- a/migrations/0014_create_table_missiongoal.py
+++ b/migrations/0014_create_table_missiongoal.py
@@ -1,0 +1,18 @@
+"""
+create table missiongoal
+date created: 2019-05-04 20:40:35.201100
+"""
+
+
+def upgrade(migrator):
+  with migrator.create_table('missiongoal') as table:
+    table.primary_key('id')
+    table.foreign_key('AUTO', 'mission_id', on_delete=None, on_update=None, references='mission.id')
+    table.foreign_key('AUTO', 'goal_id', on_delete=None, on_update=None, references='goal.id')
+    table.integer('week')
+    table.char('created_at')
+    table.char('deleted_at', null=True)
+
+
+def downgrade(migrator):
+    migrator.drop_table('missiongoal')

--- a/migrations/0015_rebake_test_mission_using_join_table.py
+++ b/migrations/0015_rebake_test_mission_using_join_table.py
@@ -1,0 +1,16 @@
+"""
+rebake test mission using join table
+date created: 2019-05-04 20:52:40.627367
+"""
+
+def upgrade(migrator):
+  migrator.execute_sql(
+    '''insert into missiongoal (mission_id, goal_id, week, created_at)
+       select goal.mission_id as mission_id,
+              goal.id as goal_id,
+              goal.week as week,
+              goal.created_at as created_at
+       from goal;''')
+
+def downgrade(migrator):
+  migrator.execute_sql('delete from missiongoal')

--- a/migrations/0016_drop_unused_mission_and_goal_fields.py
+++ b/migrations/0016_drop_unused_mission_and_goal_fields.py
@@ -1,0 +1,27 @@
+"""
+drop unused mission and goal fields
+date created: 2019-05-04 21:44:40.156692
+"""
+from peewee import IntegerField, BooleanField
+
+def add_foreign_key(migrator, from_table, from_field, to_table, to_field, **kwargs):
+  """Add a foreign key, which playhouse-moves doesn't seem to do properly."""
+  migrator.add_column(from_table, from_field, 'int', **kwargs)
+  playhouse_migrator = migrator.migrator
+  playhouse_migrator.add_foreign_key_constraint(from_table, from_field, to_table, to_field).run()
+
+def upgrade(migrator):
+  migrator.drop_column('goal', 'week')
+  migrator.drop_column('goal', 'mission_id')
+  migrator.drop_column('goal', 'primary_for_mission')
+  migrator.drop_column('mission', 'prerequisite_id')
+
+def downgrade(migrator):
+  add_foreign_key(migrator, 'mission', 'prerequisite_id', 'mission', 'id', null=True)
+  migrator.add_column('goal', 'primary_for_mission', BooleanField, default=True)
+  add_foreign_key(migrator, 'goal', 'mission_id', 'mission', 'id', null=True)
+  migrator.add_column('goal', 'week', IntegerField, default=0)
+  migrator.execute_sql(
+    '''update goal g
+       inner join missiongoal mg on g.id = mg.goal_id
+       set g.week = mg.week, g.mission_id = mg.mission_id''')

--- a/migrations/0016_drop_unused_mission_and_goal_fields.py
+++ b/migrations/0016_drop_unused_mission_and_goal_fields.py
@@ -2,7 +2,6 @@
 drop unused mission and goal fields
 date created: 2019-05-04 21:44:40.156692
 """
-from peewee import IntegerField, BooleanField
 
 def add_foreign_key(migrator, from_table, from_field, to_table, to_field, **kwargs):
   """Add a foreign key, which playhouse-moves doesn't seem to do properly."""
@@ -18,9 +17,9 @@ def upgrade(migrator):
 
 def downgrade(migrator):
   add_foreign_key(migrator, 'mission', 'prerequisite_id', 'mission', 'id', null=True)
-  migrator.add_column('goal', 'primary_for_mission', BooleanField, default=True)
+  migrator.add_column('goal', 'primary_for_mission', 'bool', default=True)
   add_foreign_key(migrator, 'goal', 'mission_id', 'mission', 'id', null=True)
-  migrator.add_column('goal', 'week', IntegerField, default=0)
+  migrator.add_column('goal', 'week', 'int', default=0)
   migrator.execute_sql(
     '''update goal g
        inner join missiongoal mg on g.id = mg.goal_id

--- a/migrations/0017_add_frozen_to_mission.py
+++ b/migrations/0017_add_frozen_to_mission.py
@@ -1,0 +1,17 @@
+"""
+add frozen to mission
+date created: 2019-05-05 18:42:58.476185
+"""
+
+from peewee import BooleanField, CharField, IntegerField
+
+def upgrade(migrator):
+  migrator.add_column('mission', 'frozen', BooleanField, default=False)
+  migrator.execute_sql('update mission set frozen=true;')
+  migrator.add_column('mission', 'duration_in_weeks', IntegerField, default=4)
+  migrator.add_column('mission', 'started_at', CharField, null=True)
+
+def downgrade(migrator):
+  migrator.drop_column('mission', 'frozen')
+  migrator.drop_column('mission', 'duration_in_weeks')
+  migrator.drop_column('mission', 'started_at')

--- a/migrations/0017_add_frozen_to_mission.py
+++ b/migrations/0017_add_frozen_to_mission.py
@@ -3,13 +3,11 @@ add frozen to mission
 date created: 2019-05-05 18:42:58.476185
 """
 
-from peewee import BooleanField, CharField, IntegerField
-
 def upgrade(migrator):
-  migrator.add_column('mission', 'frozen', BooleanField, default=False)
+  migrator.add_column('mission', 'frozen', 'bool', default=False)
   migrator.execute_sql('update mission set frozen=true;')
-  migrator.add_column('mission', 'duration_in_weeks', IntegerField, default=4)
-  migrator.add_column('mission', 'started_at', CharField, null=True)
+  migrator.add_column('mission', 'duration_in_weeks', 'int', default=4)
+  migrator.add_column('mission', 'started_at', 'char', null=True)
 
 def downgrade(migrator):
   migrator.drop_column('mission', 'frozen')

--- a/migrations/0018_drop_mission_started_at_from_team.py
+++ b/migrations/0018_drop_mission_started_at_from_team.py
@@ -1,0 +1,11 @@
+"""
+drop mission_started_at from team
+date created: 2019-05-05 19:10:41.028519
+"""
+from peewee import CharField
+
+def upgrade(migrator):
+  migrator.drop_column('team', 'mission_start_at')
+
+def downgrade(migrator):
+  migrator.add_column('team', 'mission_start_at', CharField, null=True)

--- a/migrations/0018_drop_mission_started_at_from_team.py
+++ b/migrations/0018_drop_mission_started_at_from_team.py
@@ -2,10 +2,8 @@
 drop mission_started_at from team
 date created: 2019-05-05 19:10:41.028519
 """
-from peewee import CharField
-
 def upgrade(migrator):
   migrator.drop_column('team', 'mission_start_at')
 
 def downgrade(migrator):
-  migrator.add_column('team', 'mission_start_at', CharField, null=True)
+  migrator.add_column('team', 'mission_start_at', 'char', null=True)

--- a/migrations/0019_add_category_to_goal.py
+++ b/migrations/0019_add_category_to_goal.py
@@ -1,0 +1,10 @@
+"""
+add category to goal
+date created: 2019-05-11 23:10:47.565837
+"""
+
+def upgrade(migrator):
+  migrator.add_column('goal', 'category', 'char', default='diet')
+
+def downgrade(migrator):
+  migrator.drop_column('goal', 'category')

--- a/spaceship/forms/start_mission.py
+++ b/spaceship/forms/start_mission.py
@@ -1,6 +1,0 @@
-
-from flask_wtf import FlaskForm
-from wtforms import SubmitField
-
-class StartMission(FlaskForm):
-  start = SubmitField('Start Mission')

--- a/spaceship/models/goal.py
+++ b/spaceship/models/goal.py
@@ -11,6 +11,7 @@ from .mission import Mission
 class Goal(BaseModel):
   id = AutoField(primary_key=True)
   short_description = CharField()
+  category = CharField(default='diet')
   created_at = PendulumDateTimeField(default=lambda: pendulum.now('UTC'))
   deleted_at = PendulumDateTimeField(null=True)
 

--- a/spaceship/models/mission.py
+++ b/spaceship/models/mission.py
@@ -22,14 +22,14 @@ class Mission(BaseModel):
     return self.deleted_at == None
 
   def start(self):
-    return self.clone(start=True)
+    return self.clone(start=True, frozen=True)
 
-  def clone(self, start=False):
+  def clone(self, start=False, frozen=False):
     clone = Mission()
     clone.title = self.title
     clone.short_description = self.short_description
+    clone.frozen = frozen
     if start:
-      clone.frozen = True
       clone.started_at = pendulum.now('UTC')
     clone.save()
     # import here instead of top-level to avoid a cycle

--- a/spaceship/models/mission.py
+++ b/spaceship/models/mission.py
@@ -11,12 +11,33 @@ class Mission(BaseModel):
   id = AutoField(primary_key=True)
   title = CharField()
   short_description = CharField()
+  duration_in_weeks = SmallIntegerField(default=4)
+  frozen = BooleanField(default=False)
+  started_at = PendulumDateTimeField(null=True)
   created_at = PendulumDateTimeField(default=lambda: pendulum.now('UTC'))
   deleted_at = PendulumDateTimeField(null=True)
 
   @hybrid_property
   def is_active(self):
     return self.deleted_at == None
+
+  def start(self):
+    return self.clone(start=True)
+
+  def clone(self, start=False):
+    clone = Mission()
+    clone.title = self.title
+    clone.short_description = self.short_description
+    if start:
+      clone.frozen = True
+      clone.started_at = pendulum.now('UTC')
+    clone.save()
+    # import here instead of top-level to avoid a cycle
+    from .mission_goal import MissionGoal
+    for slot in self.goal_slots():
+      clone_slot = MissionGoal(mission=clone, goal=slot.goal, week=slot.week)
+      clone_slot.save()
+    return clone
 
   def goal_slots(self, week=None):
     # import here instead of top-level to avoid a cycle

--- a/spaceship/models/mission.py
+++ b/spaceship/models/mission.py
@@ -32,7 +32,6 @@ class Mission(BaseModel):
     if start:
       clone.started_at = pendulum.now('UTC')
     clone.save()
-    # import here instead of top-level to avoid a cycle
     from .mission_goal import MissionGoal
     for slot in self.goal_slots():
       clone_slot = MissionGoal(mission=clone, goal=slot.goal, week=slot.week)
@@ -40,7 +39,6 @@ class Mission(BaseModel):
     return clone
 
   def goal_slots(self, week=None):
-    # import here instead of top-level to avoid a cycle
     from .mission_goal import MissionGoal
     if week is None:
       return (MissionGoal
@@ -50,3 +48,20 @@ class Mission(BaseModel):
             .select()
             .where((MissionGoal.mission_id == self.id) &
                    (MissionGoal.week == week)))
+
+  def serialize_for_js(self):
+    schedule = []
+    for week in range(1 + self.duration_in_weeks):
+      schedule.append([{'goal_id': g.goal.id} for g in self.goal_slots(week=week)])
+    return {'schedule': schedule}
+
+  def update_from_js(self, state):
+    from .mission_goal import MissionGoal
+    schedule = state['schedule']
+    self.duration_in_weeks = max(0, len(schedule) - 1)
+    MissionGoal.delete().where(MissionGoal.mission_id == self.id).execute()
+    for week_number, week in enumerate(schedule):
+      for slot in week:
+        MissionGoal.insert(mission_id=self.id,
+                           goal_id=slot['goal_id'],
+                           week=week_number).execute()

--- a/spaceship/models/mission.py
+++ b/spaceship/models/mission.py
@@ -11,10 +11,21 @@ class Mission(BaseModel):
   id = AutoField(primary_key=True)
   title = CharField()
   short_description = CharField()
-  prerequisite = ForeignKeyField('self', null=True, backref='children')
   created_at = PendulumDateTimeField(default=lambda: pendulum.now('UTC'))
   deleted_at = PendulumDateTimeField(null=True)
 
   @hybrid_property
   def is_active(self):
     return self.deleted_at == None
+
+  def goal_slots(self, week=None):
+    # import here instead of top-level to avoid a cycle
+    from .mission_goal import MissionGoal
+    if week is None:
+      return (MissionGoal
+              .select()
+              .where(MissionGoal.mission_id == self.id))
+    return (MissionGoal
+            .select()
+            .where((MissionGoal.mission_id == self.id) &
+                   (MissionGoal.week == week)))

--- a/spaceship/models/mission_goal.py
+++ b/spaceship/models/mission_goal.py
@@ -7,13 +7,11 @@ from ..db import BaseModel
 
 from .custom_fields import PendulumDateTimeField
 from .mission import Mission
+from .goal import Goal
 
-class Goal(BaseModel):
-  id = AutoField(primary_key=True)
-  short_description = CharField()
+class MissionGoal(BaseModel):
+  mission = ForeignKeyField(Mission, backref='memberships')
+  goal = ForeignKeyField(Goal, backref='memberships')
+  week = SmallIntegerField()
   created_at = PendulumDateTimeField(default=lambda: pendulum.now('UTC'))
   deleted_at = PendulumDateTimeField(null=True)
-
-  @hybrid_property
-  def is_active(self):
-    return self.deleted_at == None

--- a/spaceship/models/team.py
+++ b/spaceship/models/team.py
@@ -18,7 +18,6 @@ class Team(BaseModel):
   deleted_at = PendulumDateTimeField(null=True)
 
   mission = ForeignKeyField(Mission, backref='mission', null=True)
-  mission_start_at = PendulumDateTimeField(null=True)
 
   @hybrid_property
   def is_active(self):

--- a/spaceship/static/spaceship.css
+++ b/spaceship/static/spaceship.css
@@ -122,6 +122,29 @@ main {
   margin: 8px;
   min-height: 100px;
 }
+.goal-category {
+  font-size: 80%;
+  position: relative;
+  top: -10px;
+  left: -4px;
+  font-style: italic;
+}
+.goal-header::before {
+  content: "";
+  display: block;
+  position: relative;
+  left: -10px;
+  top: -10px;
+  border-top-left-radius: 4px;
+  width: 25%;
+  height: 8px;
+}
+[data-category="diet"].goal-header::before {
+  background: #090;
+}
+[data-category="energy"].goal-header::before {
+  background: #900;
+}
 
 .active-goal {
   background: #fff;

--- a/spaceship/static/spaceship.css
+++ b/spaceship/static/spaceship.css
@@ -128,6 +128,7 @@ main {
   top: -10px;
   left: -4px;
   font-style: italic;
+  color: #666;
 }
 .goal-header::before {
   content: "";

--- a/spaceship/static/spaceship.css
+++ b/spaceship/static/spaceship.css
@@ -42,7 +42,7 @@ main {
   padding-bottom: 8px;
 }
 
-.btn {
+.btn-primary {
   border-color: #ed604e;
   background-color: #ed6a5a;
 }
@@ -150,4 +150,43 @@ main {
 
 .goal-progress {
   font-size: 80%;
+}
+
+.edit-controls {
+  border: 1px solid #ccc;
+  border-radius: 5px;
+  padding: 4px;
+  margin: 8px;
+  margin-bottom: 0px;
+  background-color: #efefef;
+}
+.edit-controls .btn {
+  margin: 2px;
+}
+.make-goal-primary {
+  display: none;
+}
+[data-week="1"] .move-goal-up {
+  display: none;
+}
+[data-week="0"] .make-goal-primary {
+  display: block;
+}
+[data-week="0"] .make-goal-secondary,
+[data-week="0"] .move-goal-up,
+[data-week="0"] .move-goal-down {
+  display: none;
+}
+.unscheduled .remove-goal,
+.unscheduled .move-goal-up,
+.unscheduled .move-goal-down {
+  display: none;
+}
+.unscheduled .make-goal-primary,
+.unscheduled .make-goal-secondary {
+  display: block;
+  margin-left: 0!important;
+}
+.focused-goal {
+  background: #f4f1bb;
 }

--- a/spaceship/static/spaceship.css
+++ b/spaceship/static/spaceship.css
@@ -158,7 +158,7 @@ main {
   padding: 4px;
   margin: 8px;
   margin-bottom: 0px;
-  background-color: #efefef;
+  background-color: #d0adad;
 }
 .edit-controls .btn {
   margin: 2px;

--- a/spaceship/templates/goal.html
+++ b/spaceship/templates/goal.html
@@ -1,6 +1,5 @@
 {% set pledged   = goal.id in my_pledges %}
 {% set fulfilled = my_pledges[goal.id].fulfilled if pledged else False %}
-{% set active = week_of_mission > 0 and week_of_mission <= 4 and week_of_mission >= goal.week %}
 
 <div class="goal{% if active %} active-goal{% endif %}" data-goal="{{ goal.id }}">
   <div>{{ goal.short_description }}</div>

--- a/spaceship/templates/goal.html
+++ b/spaceship/templates/goal.html
@@ -2,6 +2,9 @@
 {% set fulfilled = my_pledges[goal.id].fulfilled if pledged else False %}
 
 <div class="goal{% if active %} active-goal{% endif %}" data-goal="{{ goal.id }}">
+  <div class="goal-header" data-category="{{ goal.category }}">
+    <div class="goal-category">{{ goal.category }}</div>
+  </div>
   <div>{{ goal.short_description }}</div>
   {% if active %}
   <div class="goal-progress-wrapper"

--- a/spaceship/templates/goal.html
+++ b/spaceship/templates/goal.html
@@ -5,7 +5,7 @@
   <div>{{ goal.short_description }}</div>
   {% if active %}
   <div class="goal-progress-wrapper"
-       data-update-url="{{ url_for('goal_progress', team_id=team.id, goal_id=goal.id, start_at=team.mission_start_at) }}">
+       data-update-url="{{ url_for('goal_progress', team_id=team.id, mission_id=team.mission.id, goal_id=goal.id) }}">
     {% set progress = goal_progress[goal.id] %}
     {% set my_pledge_id = my_pledges[goal.id].id if pledged else -1 %}
     {% include "goal_progress.html" %}

--- a/spaceship/templates/goal_search.html
+++ b/spaceship/templates/goal_search.html
@@ -1,0 +1,6 @@
+{% set active = false %}
+{% set my_pledges = {} %}
+{% set goal_progress = {} %}
+{% for goal in goals %}
+{% include 'goal.html' %}
+{% endfor %}

--- a/spaceship/templates/mission.html
+++ b/spaceship/templates/mission.html
@@ -1,16 +1,47 @@
+{% from 'editable.html' import editable_text %}
 {% extends "base.html" %}
 
 {% block title %}Mission - {{ super() }}{% endblock %}
 
 {% block content %}
-<h5>
-    <a href="{{ url_for('roster', team_id=team) }}"> {{ team.name }} </a>
-</h5>
+<h5><a href="{{ url_for('roster', team_id=team) }}">{{ team.name }}</a></h5>
 
-<h3>{{ mission.title }}</h3>
+<div>
+{% if is_captain and not team.mission %}
+<form style="display: inline-block"
+      action="{{ url_for('mission', team_id=team, mission_id=mission) }}"
+      method="POST">
+  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+  <input type="hidden" name="start_mission" value="1">
+  <button type="submit" class="btn btn-primary"><i class="fas fa-play"></i> Start mission</button>
+</form>
+{% endif %}
+{% if is_captain and mission.frozen %}
+<form style="display: inline-block"
+      action="{{ url_for('mission', team_id=team, mission_id=mission) }}"
+      method="POST">
+  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+  <input type="hidden" name="copy" value="1">
+  <button type="submit" class="btn btn-primary"><i class="fas fa-copy"></i>&nbsp; Copy and customize</button>
+</form>
+{% endif %}
+</div>
+
+{% set can_edit = is_captain and not mission.frozen %}
+<h3>{{ editable_text(text=mission.title,
+                     is_editable=can_edit,
+                     popup_title="Edit title",
+                     table="mission", id=mission.id, field="title") }}</h3>
+<!--
 <p><a href="{{ url_for('show_mission_info', mission_id=mission.id) }}">MISSION BRIEF HERE</a></p>
-<p>{{ mission.short_description }}</p>
-{% if week_of_mission > 0 and week_of_mission <= 4 %}
+-->
+<p>{{ editable_text(text=mission.short_description,
+                    is_editable=can_edit,
+                    multiline=True,
+                    popup_title="Edit description",
+                    table="mission", id=mission.id, field='short_description') }}</p>
+
+{% if week_of_mission > 0 and week_of_mission <= mission.duration_in_weeks %}
 <p>Click "Pledge" below for any goals you want to complete. Afterwards, click the "Done" checkbox to mark goals you have completed.
 <p>In week {{ week_of_mission }}!
 <p><a class="btn btn-primary" data-toggle="collapse" href="#calendar" role="button" aria-expanded="false" aria-controls="calendar">Toggle calendar</a>
@@ -31,37 +62,6 @@ should encourage each person to pledge for and complete as many goals as
 possible. At the start of every week, a new primary goal will open
 up&mdash;this is a good time to check in. Some bonus, secondary goals may be
 completed at any time during the mission.
-
-<p>Commit your crew to this mission for one month?
-<form method="POST" class="needs-validation" novalidate>
-  {% for field in start_mission %}
-  {% set errors = start_mission.errors[field.name] %}
-  {% if field.flags.hidden %}
-    {{ field(class="form-control") }}
-  {% elif field.type == "SubmitField" %}
-    {{ field(class="btn btn-primary") }}
-  {% else %}
-    {% if errors %}
-    {% set class="form-control is-invalid" %}
-    {% else %}
-    {% set class="form-control" %}
-    {% endif %}
-
-    <div class="row">
-      <span class="col-3">{{ field.label() }}</span>
-    </div>
-    <div class="row form-box">
-      <span class="col-6">
-      {{ field(class=class) }}
-      <div class="invalid-feedback">
-        {{ ';'.join(errors) }}
-      </div>
-      {{ field.description }}
-      </span>
-    </div>
-  {% endif %}
-  {% endfor %}
-</form>
 {% endif %}
 {% endif %}
 

--- a/spaceship/templates/mission.html
+++ b/spaceship/templates/mission.html
@@ -134,6 +134,7 @@ during the mission.
 <div class="row">
 <section class="unscheduled col-sm-6">
 <h4>Unscheduled Goals</h4>
+<button type="button" id="search" class="btn btn-primary">Search</button>
 <div data-week="-1">
 </div>
 </section>
@@ -295,6 +296,32 @@ $('#duration').change(function() {
   var durationInWeeks = parseInt($(this).val());
   changeDuration(durationInWeeks);
   sync();
+});
+
+function getScheduledGoals() {
+  var goals = [];
+  var schedule = state['schedule'];
+  for (var week = 0; week < schedule.length; week++) {
+    for (var i = 0; i < schedule[week].length; i++) {
+      goals.push(schedule[week][i]['goal_id']);
+    }
+  }
+  return goals;
+}
+
+$('#search').click(function() {
+  var resultsDiv = $('[data-week="-1"]');
+  $.get('/goal_search', function(html) {
+    var scheduledGoals = getScheduledGoals();
+    state['unscheduled'] = [];
+    var results = $(html).filter('.goal').filter(function() {
+      return !scheduledGoals.includes($(this).data('goal'));
+    }).map(function() {
+      state['unscheduled'].push({'goal_id': $(this).data('goal')});
+      return appendEditControls($(this));
+    }).get();
+    resultsDiv.empty().append(results);
+  });
 });
 
 })();

--- a/spaceship/templates/mission.html
+++ b/spaceship/templates/mission.html
@@ -187,8 +187,8 @@ function appendEditControls(goal) {
       <button type="button" class="move-goal-up btn btn-primary" title="Move up"><i class="fas fa-arrow-circle-up"></i></button>
     </div>
     <div class="btn-group mr-2 ml-auto" role="group" aria-label="Change importance">
-      <button type="button" class="make-goal-secondary btn btn-primary ml-auto" title="Make secondary"><i class="fas fa-calendar-minus"></i></button>
       <button type="button" class="make-goal-primary btn btn-primary ml-auto" title="Make primary"><i class="fas fa-calendar-plus"></i></button>
+      <button type="button" class="make-goal-secondary btn btn-primary ml-auto" title="Make secondary"><i class="fas fa-calendar-minus"></i></button>
     </div>
     <div class="btn-group mr-2" role="group" aria-label="Remove">
       <button type="button" class="remove-goal btn btn-primary" title="Remove"><i class="fas fa-times-circle"></i></button>

--- a/spaceship/templates/mission.html
+++ b/spaceship/templates/mission.html
@@ -282,6 +282,9 @@ function moveGoal(fromContext, toWeek) {
   var goal = state['unscheduled'].pop();
   var schedule = state['schedule'];
   schedule[toWeek].push(goal);
+  while (schedule.length && schedule[schedule.length - 1].length == 0) {
+    schedule.pop();
+  }
 }
 
 function findContext(element) {

--- a/spaceship/templates/mission.html
+++ b/spaceship/templates/mission.html
@@ -1,7 +1,7 @@
 {% from 'editable.html' import editable_text %}
 {% extends "base.html" %}
 {% set can_edit = is_captain and not mission.frozen %}
-{% set max_weeks = 8 %};
+{% set max_weeks = 8 %}
 
 {% block title %}Mission - {{ super() }}{% endblock %}
 

--- a/spaceship/templates/mission.html
+++ b/spaceship/templates/mission.html
@@ -203,7 +203,8 @@ function appendEditControls(goal) {
   });
   $(dom).find('.make-goal-primary').click(function() {
     var context = findContext(this);
-    moveGoal(context, 1);
+    var targetWeek = findFirstOpenWeek();
+    moveGoal(context, targetWeek);
     focusedGoalId = context.goalId;
     sync();
   });
@@ -239,6 +240,16 @@ function sync() {
       // TODO: handle errors
     }
   });
+}
+
+function findFirstOpenWeek() {
+  var schedule = state['schedule'];
+  for (var i = 1; i < schedule.length; i++) {
+    if (schedule[i].length == 0) {
+      return i;
+    }
+  }
+  return 1;
 }
 
 function changeDuration(durationInWeeks) {

--- a/spaceship/templates/mission.html
+++ b/spaceship/templates/mission.html
@@ -1,5 +1,6 @@
 {% from 'editable.html' import editable_text %}
 {% extends "base.html" %}
+{% set can_edit = is_captain and not mission.frozen %}
 
 {% block title %}Mission - {{ super() }}{% endblock %}
 
@@ -46,7 +47,6 @@
 {% endif %}
 </div>
 
-{% set can_edit = is_captain and not mission.frozen %}
 <h3>{{ editable_text(text=mission.title,
                      is_editable=can_edit,
                      popup_title="Edit title",
@@ -87,32 +87,160 @@ completed at any time during the mission.
 <div class="row">
 <section class="primary col-sm-6">
 <h4>Primary Goals</h4>
-{% for week in range(1,5): %} 
+{% for week in range(1, 1 + mission.duration_in_weeks): %}
 <h5>Week {{ week }}</h5>
-{% for slot in mission.goal_slots(week=week): %}
-{% set goal = slot.goal %}
-{% set active = week_of_mission > 0 and week_of_mission <= 4 and week_of_mission >= week %}
-{% include "goal.html" %}
-{% endfor %}
+<div data-week="{{ week }}">
+  {% for slot in mission.goal_slots(week=week): %}
+  {% set goal = slot.goal %}
+  {% set active = week_of_mission > 0 and week_of_mission <= mission.duration_in_weeks and week_of_mission >= week %}
+  {% include "goal.html" %}
+  {% endfor %}
+</div>
 {% endfor %}
 </section>
 
 <section class="bonus col-sm-6">
 <h4>Secondary Goals</h4>
 <h5>Any time</h5>
-{% for slot in mission.goal_slots(week=0): %}
-{% set goal = slot.goal %}
-{% set active = week_of_mission > 0 and week_of_mission <= 4 %}
-{% include "goal.html" %}
-{% endfor %}
+<div data-week="0">
+  {% for slot in mission.goal_slots(week=0): %}
+  {% set goal = slot.goal %}
+  {% set active = week_of_mission > 0 and week_of_mission <= mission.duration_in_weeks %}
+  {% include "goal.html" %}
+  {% endfor %}
+</div>
 </section>
 </div>
+
+{% if can_edit %}
+<div class="row">
+<section class="unscheduled col-sm-6">
+<h4>Unscheduled Goals</h4>
+<div data-week="-1">
 </div>
+</section>
+</div>
+{% endif %}
 
 {% endblock %}
 
 {% block scripts %}
 {{ super() }}
+
+{% if can_edit %}
+<script>
+(function() {
+var state = {{ mission_js_model|tojson }};
+var focusedGoalId = -1;
+render();
+
+function render() {
+  $('.goal').detach().appendTo($('[data-week="-1"]'));
+  var schedule = state['schedule'];
+  for (var week = 0; week < schedule.length; week++) {
+    var weekDiv = $('[data-week="' + week + '"]');
+    for (var i = 0; i < schedule[week].length; i++) {
+      var slot = schedule[week][i];
+      var goalId = slot['goal_id'];
+      var goal = $('.goal[data-goal="' + goalId + '"]');
+      appendEditControls(goal);
+      weekDiv.append(goal);
+    }
+  }
+  $('.goal').each(function() {
+    var goalId = parseInt($(this).data('goal'));
+    $(this).toggleClass('focused-goal', focusedGoalId == goalId);
+  });
+}
+
+function appendEditControls(goal) {
+  if (goal.find('.edit-controls').length !== 0) {
+    return;
+  }
+  var dom = goal.append(`<div class="row edit-controls">
+    <a class="move-goal-down btn btn-primary" title="Move down"><i class="fas fa-arrow-circle-down"></i></a>
+    <a class="move-goal-up btn btn-primary" title="Move up"><i class="fas fa-arrow-circle-up"></i></a>
+    <a class="make-goal-primary btn btn-primary ml-auto" title="Make primary"><i class="fas fa-calendar-plus"></i></a>
+    <a class="make-goal-secondary btn btn-primary ml-auto" title="Make secondary"><i class="fas fa-calendar-minus"></i></a>
+    <a class="remove-goal btn btn-primary" title="Remove"><i class="fas fa-times-circle"></i></a>
+  </div>`);
+  $(dom).find('.remove-goal').click(function() {
+    var context = findContext(this);
+    removeGoal(context);
+    focusedGoalId = -1;
+    sync();
+  });
+  $(dom).find('.make-goal-primary').click(function() {
+    var context = findContext(this);
+    moveGoal(context, 1);
+    focusedGoalId = context.goalId;
+    sync();
+  });
+  $(dom).find('.make-goal-secondary').click(function() {
+    var context = findContext(this);
+    moveGoal(context, 0);
+    focusedGoalId = context.goalId;
+    sync();
+  });
+  $(dom).find('.move-goal-down').click(function() {
+    var context = findContext(this);
+    moveGoal(context, context.week + 1);
+    focusedGoalId = context.goalId;
+    sync();
+  });
+  $(dom).find('.move-goal-up').click(function() {
+    var context = findContext(this);
+    moveGoal(context, context.week - 1);
+    focusedGoalId = context.goalId;
+    sync();
+  });
+  return dom;
+}
+
+function sync() {
+  $.post('{{ url_for('mission', team_id=team, mission_id=mission) }}', {
+    'edit': true,
+    'state': JSON.stringify(state)
+  }).done(function(json) {
+    if (json['ok']) {
+      render();
+    } else {
+      // TODO: handle errors
+    }
+  });
+}
+
+function removeGoal(context) {
+  state['unscheduled'] = state['unscheduled'] || [];
+  var week = context.week == -1 ? state['unscheduled'] : state['schedule'][context.week];
+  var goalIndex = week.findIndex(function(slot) {
+    return slot['goal_id'] == context.goalId;
+  });
+  if (goalIndex == -1) {
+    return;
+  }
+  var slots = week.splice(goalIndex, 1);
+  state['unscheduled'].push(slots[0]);
+}
+
+function moveGoal(fromContext, toWeek) {
+  removeGoal(fromContext);
+  var goal = state['unscheduled'].pop();
+  var schedule = state['schedule'];
+  schedule[toWeek].push(goal);
+}
+
+function findContext(element) {
+  var weekDiv = $(element).parents('[data-week]');
+  var weekNumber = parseInt($(weekDiv).data('week'), 10);
+  var goalDiv = $(element).parents('[data-goal]');
+  var goalId = parseInt($(goalDiv).data('goal'), 10);
+  return {week: weekNumber, goalId: goalId};
+}
+})();
+</script>
+{% endif %}
+
 <script>
 {% if is_captain and not team.mission %}
 $('#start').click(function(e) {
@@ -125,7 +253,6 @@ $('#confirm-start').click(function() {
   $('#start-form').submit();
 })
 {% endif %}
-
 function updateProgress(goalDiv) {
   var progress = goalDiv.find('.goal-progress-wrapper');
   var updateUrl = progress.data('update-url')

--- a/spaceship/templates/mission.html
+++ b/spaceship/templates/mission.html
@@ -70,10 +70,10 @@ completed at any time during the mission.
 <h4>Primary Goals</h4>
 {% for week in range(1,5): %} 
 <h5>Week {{ week }}</h5>
-{% for goal in mission.goals: %}
-{% if goal.week == week and goal.primary_for_mission %}
+{% for slot in mission.goal_slots(week=week): %}
+{% set goal = slot.goal %}
+{% set active = week_of_mission > 0 and week_of_mission <= 4 and week_of_mission >= week %}
 {% include "goal.html" %}
-{% endif %}
 {% endfor %}
 {% endfor %}
 </section>
@@ -81,10 +81,10 @@ completed at any time during the mission.
 <section class="bonus col-sm-6">
 <h4>Secondary Goals</h4>
 <h5>Any time</h5>
-{% for goal in mission.goals: %}
-{% if not goal.primary_for_mission %}
+{% for slot in mission.goal_slots(week=0): %}
+{% set goal = slot.goal %}
+{% set active = week_of_mission > 0 and week_of_mission <= 4 %}
 {% include "goal.html" %}
-{% endif %}
 {% endfor %}
 </section>
 </div>

--- a/spaceship/templates/mission.html
+++ b/spaceship/templates/mission.html
@@ -8,12 +8,31 @@
 
 <div>
 {% if is_captain and not team.mission %}
+<div class="modal fade" id="confirm-start-modal" tabindex="-1" role="dialog" aria-labelledby="confirmStartOverlayTitle" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h3 class="modal-title text-center" id="confirmStartOverlayTitle">Are you sure?</h3>
+      </div>
+      <div class="modal-body">
+        <p>Commit your team to this mission for the next {{ mission.duration_in_weeks }} weeks?
+        <p>Note: You will be unable to customize the mission after starting.
+        (You can still make a copy and customize for a later run.)
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+        <a id="confirm-start" class="btn btn-danger btn-ok">Start</a>
+      </div>
+    </div>
+  </div>
+</div>
 <form style="display: inline-block"
+      id="start-form"
       action="{{ url_for('mission', team_id=team, mission_id=mission) }}"
       method="POST">
   <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
   <input type="hidden" name="start_mission" value="1">
-  <button type="submit" class="btn btn-primary"><i class="fas fa-play"></i> Start mission</button>
+  <button id="start" type="submit" class="btn btn-primary"><i class="fas fa-play"></i>&nbsp;Start mission</button>
 </form>
 {% endif %}
 {% if is_captain and mission.frozen %}
@@ -22,7 +41,7 @@
       method="POST">
   <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
   <input type="hidden" name="copy" value="1">
-  <button type="submit" class="btn btn-primary"><i class="fas fa-copy"></i>&nbsp; Copy and customize</button>
+  <button type="submit" class="btn btn-primary"><i class="fas fa-copy"></i>&nbsp;Copy and customize</button>
 </form>
 {% endif %}
 </div>
@@ -95,6 +114,18 @@ completed at any time during the mission.
 {% block scripts %}
 {{ super() }}
 <script>
+{% if is_captain and not team.mission %}
+$('#start').click(function(e) {
+  $('#confirm-start-modal').modal({keyboard: true});
+  e.preventDefault();
+  return false;
+});
+
+$('#confirm-start').click(function() {
+  $('#start-form').submit();
+})
+{% endif %}
+
 function updateProgress(goalDiv) {
   var progress = goalDiv.find('.goal-progress-wrapper');
   var updateUrl = progress.data('update-url')

--- a/spaceship/templates/mission.html
+++ b/spaceship/templates/mission.html
@@ -1,6 +1,7 @@
 {% from 'editable.html' import editable_text %}
 {% extends "base.html" %}
 {% set can_edit = is_captain and not mission.frozen %}
+{% set max_weeks = 8 %};
 
 {% block title %}Mission - {{ super() }}{% endblock %}
 
@@ -76,25 +77,42 @@
 <p>You need some crew before you can start a mission.
 Invite people <a href="{{ url_for('roster', team_id=team, _anchor='invite') }}">here</a>.
 {% else %}
-<p>During this month long mission, your crew will attempt the goals below. You
-should encourage each person to pledge for and complete as many goals as
-possible. At the start of every week, a new primary goal will open
-up&mdash;this is a good time to check in. Some bonus, secondary goals may be
-completed at any time during the mission.
+<p>During this mission, your crew will attempt the goals below. You should
+encourage each person to pledge for and complete as many goals as possible. At
+the start of every week, a new primary goal will open up&mdash;this is a good
+time to check in. Some bonus, secondary goals may be completed at any time
+during the mission.
 {% endif %}
 {% endif %}
 
 <div class="row">
 <section class="primary col-sm-6">
 <h4>Primary Goals</h4>
+{% if can_edit %}
+<h5>Duration</h5>
+<p>How long should this mission last?
+<select id="duration" class="custom-select">
+  {% for n in range(1, max_weeks) %}
+  <option value="{{ n }}"{% if mission.duration_in_weeks == n %} selected{% endif %}>
+  {% if n == 1 %}{{ n }} week{% else %}{{ n }} weeks{% endif %}
+  </option>
+  {% endfor %}
+</select>
+{% endif %}
+
 {% for week in range(1, 1 + mission.duration_in_weeks): %}
-<h5>Week {{ week }}</h5>
 <div data-week="{{ week }}">
+<h5>Week {{ week }}</h5>
   {% for slot in mission.goal_slots(week=week): %}
   {% set goal = slot.goal %}
   {% set active = week_of_mission > 0 and week_of_mission <= mission.duration_in_weeks and week_of_mission >= week %}
   {% include "goal.html" %}
   {% endfor %}
+</div>
+{% endfor %}
+{% for week in range(1 + mission.duration_in_weeks, 8): %}
+<div data-week="{{ week }}" style="display: none">
+<h5>Week {{ week }}</h5>
 </div>
 {% endfor %}
 </section>
@@ -137,8 +155,13 @@ render();
 function render() {
   $('.goal').detach().appendTo($('[data-week="-1"]'));
   var schedule = state['schedule'];
-  for (var week = 0; week < schedule.length; week++) {
+  for (var week = 0; week < {{ max_weeks }}; week++) {
     var weekDiv = $('[data-week="' + week + '"]');
+    if (week >= schedule.length) {
+      $(weekDiv).hide();
+      continue;
+    }
+    $(weekDiv).show();
     for (var i = 0; i < schedule[week].length; i++) {
       var slot = schedule[week][i];
       var goalId = slot['goal_id'];
@@ -147,6 +170,7 @@ function render() {
       weekDiv.append(goal);
     }
   }
+  $('#duration').val('' + (schedule.length - 1));
   $('.goal').each(function() {
     var goalId = parseInt($(this).data('goal'));
     $(this).toggleClass('focused-goal', focusedGoalId == goalId);
@@ -157,12 +181,18 @@ function appendEditControls(goal) {
   if (goal.find('.edit-controls').length !== 0) {
     return;
   }
-  var dom = goal.append(`<div class="row edit-controls">
-    <a class="move-goal-down btn btn-primary" title="Move down"><i class="fas fa-arrow-circle-down"></i></a>
-    <a class="move-goal-up btn btn-primary" title="Move up"><i class="fas fa-arrow-circle-up"></i></a>
-    <a class="make-goal-primary btn btn-primary ml-auto" title="Make primary"><i class="fas fa-calendar-plus"></i></a>
-    <a class="make-goal-secondary btn btn-primary ml-auto" title="Make secondary"><i class="fas fa-calendar-minus"></i></a>
-    <a class="remove-goal btn btn-primary" title="Remove"><i class="fas fa-times-circle"></i></a>
+  var dom = goal.append(`<div class="edit-controls btn-toolbar" role="toolbar" aria-label="Scheduling toolbar">
+    <div class="btn-group mr-2" role="group" aria-label="Move goals">
+      <button type="button" class="move-goal-down btn btn-primary" title="Move down"><i class="fas fa-arrow-circle-down"></i></button>
+      <button type="button" class="move-goal-up btn btn-primary" title="Move up"><i class="fas fa-arrow-circle-up"></i></button>
+    </div>
+    <div class="btn-group mr-2 ml-auto" role="group" aria-label="Change importance">
+      <button type="button" class="make-goal-secondary btn btn-primary ml-auto" title="Make secondary"><i class="fas fa-calendar-minus"></i></button>
+      <button type="button" class="make-goal-primary btn btn-primary ml-auto" title="Make primary"><i class="fas fa-calendar-plus"></i></button>
+    </div>
+    <div class="btn-group mr-2" role="group" aria-label="Remove">
+      <button type="button" class="remove-goal btn btn-primary" title="Remove"><i class="fas fa-times-circle"></i></button>
+    </div>
   </div>`);
   $(dom).find('.remove-goal').click(function() {
     var context = findContext(this);
@@ -210,6 +240,22 @@ function sync() {
   });
 }
 
+function changeDuration(durationInWeeks) {
+  var schedule = state['schedule'];
+  for (var week = durationInWeeks + 1; week < schedule.length; week++) {
+    for (var i = 0; i < schedule[week].length; i++) {
+      var slot = schedule[week][i];
+      removeGoal({week: week, goalId: slot['goal_id']});
+    }
+  }
+  while (schedule.length > durationInWeeks + 1) {
+    schedule.pop();
+  }
+  while (schedule.length < durationInWeeks + 1) {
+    schedule.push([]);
+  }
+}
+
 function removeGoal(context) {
   state['unscheduled'] = state['unscheduled'] || [];
   var week = context.week == -1 ? state['unscheduled'] : state['schedule'][context.week];
@@ -224,6 +270,13 @@ function removeGoal(context) {
 }
 
 function moveGoal(fromContext, toWeek) {
+  var schedule = state['schedule'];
+  if (toWeek >= schedule.length) {
+    if (toWeek >= {{ max_weeks }}) {
+      return;
+    }
+    changeDuration(toWeek);
+  }
   removeGoal(fromContext);
   var goal = state['unscheduled'].pop();
   var schedule = state['schedule'];
@@ -237,6 +290,13 @@ function findContext(element) {
   var goalId = parseInt($(goalDiv).data('goal'), 10);
   return {week: weekNumber, goalId: goalId};
 }
+
+$('#duration').change(function() {
+  var durationInWeeks = parseInt($(this).val());
+  changeDuration(durationInWeeks);
+  sync();
+});
+
 })();
 </script>
 {% endif %}

--- a/spaceship/templates/mission.html
+++ b/spaceship/templates/mission.html
@@ -223,6 +223,10 @@ function appendEditControls(goal) {
   $(dom).find('.move-goal-up').click(function() {
     var context = findContext(this);
     moveGoal(context, context.week - 1);
+    var schedule = state['schedule'];
+    while (schedule.length && schedule[schedule.length - 1].length == 0) {
+      schedule.pop();
+    }
     focusedGoalId = context.goalId;
     sync();
   });
@@ -293,9 +297,6 @@ function moveGoal(fromContext, toWeek) {
   var goal = state['unscheduled'].pop();
   var schedule = state['schedule'];
   schedule[toWeek].push(goal);
-  while (schedule.length && schedule[schedule.length - 1].length == 0) {
-    schedule.pop();
-  }
 }
 
 function findContext(element) {

--- a/spaceship/views.py
+++ b/spaceship/views.py
@@ -273,6 +273,13 @@ def goal_progress(team_id, mission_id, goal_id):
 
   return render_template('goal_progress.html', my_pledge_id=my_pledge_id, progress=progress)
 
+@app.route('/goal_search')
+def goal_search():
+  if not current_user.is_authenticated:
+    raise ValueError('auth')
+  goals = Goal.select()
+  return render_template('goal_search.html', goals=goals)
+
 def count_goal_progress(team_size=1, pledges=[]):
   progress = {'done': [], 'pledged': [], 'num_active': 0, 'num_inactive': 0}
   active = set()

--- a/spaceship/views.py
+++ b/spaceship/views.py
@@ -193,9 +193,10 @@ def mission(team_id, mission_id):
         .where((TeamUser.team_id == team.id) &
                (~((Pledge.start_at > mission_end_at) | (Pledge.end_at < team.mission_start_at)))))
       mission_calendar = calendar.layout(pendulum.today(), team.mission_start_at, mission_end_at)
-  goal_progress = {goal.id: count_goal_progress(team_size=team_size,
-                                                pledges=[p for p in mission_pledges if p.goal_id == goal.id])
-                   for goal in mission.goals}
+  goal_progress = {}
+  for slot in mission.goal_slots():
+    pledges = [p for p in mission_pledges if p.goal_id == slot.goal.id]
+    goal_progress[slot.goal.id] = count_goal_progress(team_size=team_size, pledges=pledges)
 
   my_pledges = {p.goal_id: p for p in mission_pledges if p.user_id == current_user.id}
 

--- a/tasks/run.py
+++ b/tasks/run.py
@@ -18,9 +18,10 @@ def get_db_manager():
   default=True,
   help={
     'debug': 'Whether to run flask in DEBUG mode (Default: True)',
+    'host': 'Host name to bind to (default: localhost)',
   },
 )
-def flask(ctx, debug=True):
+def flask(ctx, host='localhost', debug=True):
   """Runs the flask web server"""
   print(f"Running Flask on localhost:{PORT}...")
 
@@ -35,7 +36,7 @@ def flask(ctx, debug=True):
     pass
 
   with ctx.cd(ROOT_REPO_DIR):
-    ctx.run(f'flask run -p {PORT}', env=FLASK_ENV)
+    ctx.run(f'flask run -h {host} -p {PORT}', env=FLASK_ENV)
 
 @task
 def shell(ctx):


### PR DESCRIPTION
This is an early effort at editable missions - functional, but not polished.

I'm sending it out now because the most recent meeting notes mention data model questions, and this branch involves some important migrations. Those seem to be expensive and serial in our workflow, so I'd like to forestall conflicts.

Users can now copy missions, edit their titles/descriptions and rearrange goals. When starting a mission, we clone it and mark it "frozen", which will also simplify reconstructing history later.

Still todo:
- ACLs for ownership.
- Filtering missions to a reasonable set on the team page.
- Searching for and adding goals (including the notion of "goal categories").