### PR TITLE
Multiple sites

### DIFF
--- a/k8s/cert.yaml
+++ b/k8s/cert.yaml
@@ -1,0 +1,23 @@
+apiVersion: certmanager.k8s.io/v1alpha1
+kind: Certificate
+metadata:
+  name: spaceshipearth-org-certificate
+  namespace: {$eval: namespace}
+spec:
+  secretName: spaceshipearth-org-tls
+  acme:
+    config:
+    - dns01:
+        provider: cloud-dns-provider
+      domains:
+      - "spaceshipearth.org"
+      - "www.spaceshipearth.org"
+      - "${namespace}.spaceshipearth.org"
+  commonName: "spaceshipearth.org"
+  dnsNames:
+  - "spaceshipearth.org"
+  - "www.spaceshipearth.org"
+  - "${namespace}.spaceshipearth.org"
+  issuerRef:
+    kind: ClusterIssuer
+    name: letsencrypt-issuer

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -6,7 +6,7 @@ spec:
   selector:
     matchLabels:
       app: pyspaceship
-  replicas: 1
+  replicas: {$eval: replicas}
   template:
     metadata:
       labels:

--- a/k8s/generic_secret.yaml
+++ b/k8s/generic_secret.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {$eval: name}
+type: Opaque
+stringData: {$eval: data}

--- a/k8s/ingress.yaml
+++ b/k8s/ingress.yaml
@@ -5,10 +5,6 @@ metadata:
   namespace: {$eval: namespace}
 spec:
   tls:
-    - hosts:
-      - spaceshipearth.org
-      - www.spaceshipearth.org
-      - "${namespace}.spaceshipearth.org"
     - secretName: spaceshipearth-org-tls
   rules:
   - host: spaceshipearth.org

--- a/k8s/ingress.yaml
+++ b/k8s/ingress.yaml
@@ -2,14 +2,14 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: pyspaceship-ingress
+  namespace: {$eval: namespace}
 spec:
   tls:
     - hosts:
       - spaceshipearth.org
       - www.spaceshipearth.org
-      - test.spaceshipearth.org
-    - secretName: wildcard-spaceshipearth-org-tls
-
+      - "${namespace}.spaceshipearth.org"
+    - secretName: spaceshipearth-org-tls
   rules:
   - host: spaceshipearth.org
     http:
@@ -17,13 +17,13 @@ spec:
       - backend:
           serviceName: pyspaceship-service
           servicePort: spaceship-port
-  - host: test.spaceshipearth.org
+  - host: www.spaceshipearth.org
     http:
       paths:
       - backend:
           serviceName: pyspaceship-service
           servicePort: spaceship-port
-  - host: www.spaceshipearth.org
+  - host: "${namespace}.spaceshipearth.org"
     http:
       paths:
       - backend:

--- a/k8s/namespace.yaml
+++ b/k8s/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {$eval: namespace}

--- a/tasks/image.py
+++ b/tasks/image.py
@@ -55,10 +55,15 @@ def do_push(tag):
 
 def do_deploy(tag, ns):
   """actually perform a deploy of the manifests"""
+  replicas = 1
+  if ns.is_prod:
+    replicas = 3
+
   deployment = load_manifest(
     'deployment',
     {
       'image': tag,
+      'replicas': replicas,
     }
   )
 

--- a/tasks/image.py
+++ b/tasks/image.py
@@ -1,10 +1,9 @@
 from invoke import task, run
 from invoke.exceptions import Exit
 
-import json
 import tempfile
 
-from .utils import load_manifest, k8s_apply, in_repo_root
+from .utils import load_manifest, in_repo_root, K8SNamespace, TEST_NAMESPACE
 
 REPO = "us.gcr.io"
 PROJECT = "spaceshipearthprod"
@@ -54,7 +53,7 @@ def do_push(tag):
   print(f"Pushing docker tag {tag}...")
   run('docker push %s' % tag)
 
-def do_deploy(tag, dry_run = False):
+def do_deploy(tag, ns):
   """actually perform a deploy of the manifests"""
   deployment = load_manifest(
     'deployment',
@@ -62,28 +61,20 @@ def do_deploy(tag, dry_run = False):
       'image': tag,
     }
   )
-  k8s_apply(deployment, dry_run)
+
+  ns.apply(deployment)
 
   service = load_manifest('service')
-  k8s_apply(service, dry_run)
-
-  ingress = load_manifest('ingress')
-  k8s_apply(ingress, dry_run)
-
-  info = json.loads(run('kubectl get ingress pyspaceship-ingress -o=json', hide=True).stdout)
-  ingress = info['status']['loadBalancer']['ingress']
-  print("Load balancer IPs:")
-  for i in ingress:
-    ip = i['ip']
-    print(f'- {ip}')
+  ns.apply(service)
 
 @task(
   default=True,
   help={
     'version': "Proposed version for the release (default: hash of repo state)",
+    'namespace': f"Namespace to release to (default: {TEST_NAMESPACE})",
   },
 )
-def release(ctx, version = None):
+def release(ctx, version = None, namespace = TEST_NAMESPACE):
   """Releases a new version of the site"""
   # default to a hash of the repo state
   if not version:
@@ -117,7 +108,8 @@ def release(ctx, version = None):
     run('git push --tags')
 
   # do the deploy
-  do_deploy(docker_tag)
+  with K8SNamespace(namespace) as ns:
+    do_deploy(docker_tag, ns)
 
 @task(
   help={
@@ -144,9 +136,11 @@ def build(ctx, version=None, push=True):
 @task(
   help={
     'version': "Just the version part of the image tag",
-    'dry-run': "Just display the configuration to apply without invoking kubectl",
+    'namespace': f"Namespace to deploy into (default: {TEST_NAMESPACE}",
+    'dry-run': "Display the configuration that would be applied",
   })
-def deploy(ctx, version, dry_run = False):
+def deploy(ctx, version, namespace = TEST_NAMESPACE, dry_run = False):
   """Generates and applies k8s configuration (second part of `release`)"""
   tag = generate_tag(version)
-  do_deploy(tag)
+  with K8SNamespace(namespace, dry_run) as ns:
+    do_deploy(tag, ns)

--- a/tasks/k8s.py
+++ b/tasks/k8s.py
@@ -4,15 +4,34 @@ from invoke import task, run
 import random
 import string
 
-from . import utils
+from .utils import load_manifest, K8SNamespace, TEST_NAMESPACE
 
-@task
-def pods(ctx):
+@task(
+  help={
+    'namespace': f"Version of the site (default: {TEST_NAMESPACE})",
+  }
+)
+def pods(ctx, namespace=TEST_NAMESPACE):
   """Display existing pods for the service"""
   print('Phase\tImage\tName')
   print('------------------------------')
-  for pod in utils.get_pods():
-    print(f'{pod["phase"]}\t{pod["image"]}\t{pod["name"]}')
+  with K8SNamespace(namespace) as ns:
+    for pod in ns.get_pods():
+      print(f'{pod["phase"]}\t{pod["image"]}\t{pod["name"]}')
+
+@task
+def ingress(ctx):
+  """configure the ingress resource for all namespaces"""
+  raise NotImplementedError('this does not work right now')
+  ingress = load_manifest('ingress')
+  ns.apply(ingress)
+
+  info = json.loads(run('kubectl get ingress pyspaceship-ingress -o=json', hide=True).stdout)
+  ingress = info['status']['loadBalancer']['ingress']
+  print("Load balancer IPs:")
+  for i in ingress:
+    ip = i['ip']
+    print(f'- {ip}')
 
 @task(
   help={
@@ -21,11 +40,19 @@ def pods(ctx):
     'port': 'MySQL port (default: 3306)',
     'username': "MySQL username (default: 'spaceship-app')",
     'db': "Name of the mysql database (default: 'spaceship')",
+    'namespace': f"Version of the site (default: {TEST_NAMESPACE})",
   }
 )
-def mysql_secret(ctx, host, password, port=3306, username = 'spaceship-app', db = 'spaceship'):
+def mysql_secret(
+    ctx,
+    host,
+    password,
+    port=3306,
+    username='spaceship-app',
+    db='spaceship',
+    namespace=TEST_NAMESPACE):
   """Create a secret containing mysql credentials"""
-  secret = utils.load_manifest('mysql_secret', {
+  secret = load_manifest('mysql_secret', {
     'host': host,
     'port': str(port),
     'username': username,
@@ -33,63 +60,97 @@ def mysql_secret(ctx, host, password, port=3306, username = 'spaceship-app', db 
     'db': db,
   })
 
-  utils.k8s_apply(secret, dry_run = False)
+  with K8SNamespace(namespace) as ns:
+    ns.apply(secret)
 
-@task()
-def session_secret(ctx, secret_key = None):
+@task(
+  help={
+    'namespace': f"Version of the site (default: {TEST_NAMESPACE})",
+  }
+)
+def session_secret(ctx, secret_key = None, namespace = TEST_NAMESPACE):
+  """Creates a new session secret; this will invalidate existing sessions"""
   def random_string(length):
     return "".join( random.SystemRandom().choices(string.ascii_letters + string.digits, k=length))
 
   if not secret_key:
     secret_key = random_string(24)
 
-  secret = utils.load_manifest('session_secret', {
+  secret = load_manifest('session_secret', {
     'secret_key': secret_key,
   })
 
-  utils.k8s_apply(secret, dry_run = False)
+  with K8SNamespace(namespace) as ns:
+    ns.apply(secret)
 
-@task()
-def sendgrid_secret(ctx, secret_key = None):
-  secret = utils.load_manifest('sendgrid_secret', {
+@task(
+  help={
+    'secret-key': 'The token from sendgrid',
+    'namespace': f"Version of the site (default: {TEST_NAMESPACE})",
+  }
+)
+def sendgrid_secret(ctx, secret_key, namespace = TEST_NAMESPACE):
+  """The secret to sending email"""
+  secret = load_manifest('sendgrid_secret', {
     'secret_key': secret_key,
   })
 
-  utils.k8s_apply(secret, dry_run = False)
+  with K8SNamespace(namespace) as ns:
+    ns.apply(secret)
 
-@task()
-def google_app_secret(ctx, keyfile):
+@task(
+  help={
+    'keyfile': 'path to the json keyfile',
+    'namespace': f"Version of the site (default: {TEST_NAMESPACE})",
+  }
+)
+def google_app_secret(ctx, keyfile, namespace = TEST_NAMESPACE):
   """upload a keyfile as a google secret
 
   created by:
     gcloud iam service-accounts keys create /tmp/key.json --iam-account=pyspaceship@spaceshipearthprod.iam.gserviceaccount.com
   """
-  secret = utils.load_manifest('google-app-creds', {
+  secret = load_manifest('google-app-creds', {
     'keyfile': open(keyfile).read().strip(),
   })
 
-  utils.k8s_apply(secret, dry_run = False)
+  with K8SNamespace(namespace) as ns:
+    ns.apply(secret)
 
-
-@task()
-def run_migrations(ctx):
+@task(
+  help={
+    'namespace': f"Version of the site (default: {TEST_NAMESPACE})",
+  }
+)
+def run_migrations(ctx, namespace = TEST_NAMESPACE):
   """Migrate the DB that the cluster is connected to"""
-  random_pod_name = utils.random_pod_name()
+  with K8SNamespace(namespace) as ns:
+    random_pod_name = ns.random_pod_name()
 
-  print(f"Using pod {random_pod_name} to run migrations...")
-  run(f'kubectl exec {random_pod_name} inv run.upgrade')
+    print(f"Using pod {random_pod_name} to run migrations...")
+    run(f'{ns.kubecmd} exec {random_pod_name} inv run.upgrade')
 
-@task
-def bounce(ctx):
+@task(
+  help={
+    'namespace': f"Version of the site (default: {TEST_NAMESPACE})",
+  }
+)
+def bounce(ctx, namespace = TEST_NAMESPACE):
   """Bounce the deployment by deleting all pods and allowing them to be recreated"""
-  pod_names = [p['name'] for p in utils.get_pods() if p['phase'] == 'Running']
-  for pod_name in pod_names:
-    run(f'kubectl delete pod {pod_name}')
+  with K8SNamespace(namespace) as ns:
+    pod_names = [p['name'] for p in ns.get_pods() if p['phase'] == 'Running']
+    for pod_name in pod_names:
+      run(f'{ns.kubecmd} delete pod {pod_name}')
 
-@task()
-def shell(ctx):
+@task(
+  help={
+    'namespace': f"Version of the site (default: {TEST_NAMESPACE})",
+  }
+)
+def shell(ctx, namespace = TEST_NAMESPACE):
   """Get a shell on a random pod"""
-  random_pod_name = utils.random_pod_name()
+  with K8SNamespace(namespace) as ns:
+    random_pod_name = ns.random_pod_name()
 
-  print(f"Picked pod {random_pod_name} for shell access...")
-  run(f'kubectl exec -i -t {random_pod_name} -- /bin/bash', pty=True)
+    print(f"Picked pod {random_pod_name} for shell access...")
+    run(f'{ns.kubecmd} exec -i -t {random_pod_name} -- /bin/bash', pty=True)

--- a/tasks/utils.py
+++ b/tasks/utils.py
@@ -10,6 +10,68 @@ import yaml
 
 ROOT_REPO_DIR = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 
+DEFAULT_NAMESPACE = 'default'
+TEST_NAMESPACE = 'test'
+PROD_NAMESPACE = 'prod'
+NAMESPACES = [
+  DEFAULT_NAMESPACE,
+  TEST_NAMESPACE,
+  PROD_NAMESPACE,
+]
+
+class K8SNamespace:
+  def __init__(self, namespace, dry_run = False):
+    self.namespace = namespace
+    self.dry_run = dry_run
+
+  def __enter__(self):
+    return self
+
+  def __exit__(self, type, value, traceback):
+    self.namespace = None
+
+  def get_pods(self):
+    """List running pods"""
+    items = json.loads(
+      run(f'{self.kubecmd} get pods -l app=pyspaceship -o=json', hide=True).stdout
+    )['items']
+
+    pods = []
+    for item in items:
+      pods.append({
+        'name': item['metadata']['name'],
+        'image': item['status']['containerStatuses'][0]['image'],
+        'phase': item['status']['phase'],
+      })
+
+    return pods
+
+  def random_pod_name(self):
+    return [p['name'] for p in self.get_pods() if p['phase'] == 'Running'].pop()
+
+  @property
+  def kubecmd(self):
+    if self.namespace not in NAMESPACES:
+      raise ValueError(f"invalid namespace '{self.namespace}'")
+
+    return f"kubectl --namespace={self.namespace}"
+
+  def apply(self, manifest):
+    """run `kubectl apply` on the specified manifest"""
+    # write out the modified config
+    with tempfile.NamedTemporaryFile(mode='w') as tf:
+      yaml.dump(manifest, tf)
+      tf.flush()
+
+      if self.dry_run:
+        print("The config we generated:")
+        print(open(tf.name).read())
+        run(f'{self.kubecmd} apply --dry-run -f {tf.name}')
+
+      else:
+        run(f'{self.kubecmd} apply -f {tf.name}')
+
+
 @contextlib.contextmanager
 def in_repo_root():
   cwd = os.getcwd()
@@ -28,38 +90,3 @@ def load_manifest(mtype, context = {}):
   with open(manifest_path) as mt:
     manifest_template = yaml.safe_load(mt.read())
     return jsone.render(manifest_template, context)
-
-def k8s_apply(manifest, dry_run = True):
-  """run `kubectl apply` on the specified manifest"""
-  # write out the modified config
-  with tempfile.NamedTemporaryFile(mode='w') as tf:
-    yaml.dump(manifest, tf)
-    tf.flush()
-
-    if dry_run:
-      print("The config we generated:")
-      print(open(tf.name).read())
-      run('kubectl apply --dry-run -f %s' % tf.name)
-
-    else:
-      run('kubectl apply -f %s' % tf.name)
-
-def get_pods():
-  """List running pods"""
-  items = json.loads(
-    run('kubectl get pods -l app=pyspaceship -o=json', hide=True).stdout
-  )['items']
-
-  pods = []
-  for item in items:
-    pods.append({
-      'name': item['metadata']['name'],
-      'image': item['status']['containerStatuses'][0]['image'],
-      'phase': item['status']['phase'],
-    })
-
-  return pods
-
-def random_pod_name():
-  return [p['name'] for p in get_pods() if p['phase'] == 'Running'].pop()
-

--- a/tasks/utils.py
+++ b/tasks/utils.py
@@ -14,11 +14,14 @@ import yaml
 
 ROOT_REPO_DIR = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 
-DEFAULT_NAMESPACE = 'default'
 TEST_NAMESPACE = 'test'
 PROD_NAMESPACE = 'prod'
 
 class K8SNamespace:
+  @classmethod
+  def prod(cls):
+    return cls(PROD_NAMESPACE)
+
   def __init__(self, namespace, dry_run = False):
     self.namespace = namespace
     self.dry_run = dry_run

--- a/tasks/utils.py
+++ b/tasks/utils.py
@@ -49,6 +49,10 @@ class K8SNamespace:
     return [p['name'] for p in self.get_pods() if p['phase'] == 'Running'].pop()
 
   @property
+  def is_prod(self):
+    return self.namespace == PROD_NAMESPACE
+
+  @property
   def kubecmd(self):
     return f"kubectl --namespace={self.namespace}"
 


### PR DESCRIPTION
This PR allows us to have multiple versions of the site. Currently, i added an [igor version](https://igor.spaceshipearth.org). To add a new version do the following:

```
inv k8s.namespace <mynamespace>
inv image --namespace=<mynamespace>
inv k8s.run-migrations --namespace=<mynamespace>
```

we should have a `prod` namespace that `www` points at, but i figured we could also create our own versions that we can show to people with minimal overhead or run course-grained experiments with different approaches.

note that this PR changes all the `k8s` `invoke` commands to take an optional `--namespace` argument, you'll often want to pass `prod` or `test` or your own version