### PR TITLE
Fix email sending

### DIFF
--- a/spaceship/email.py
+++ b/spaceship/email.py
@@ -15,6 +15,7 @@ def send(to_emails, subject, html_content, from_email='gaia@spaceshipearth.org')
   if not app.config['IN_PRODUCTION']:
     log.info("Sending email:")
     log.info(html_content)
+
   try:
     message = Mail(
       from_email=from_email,

--- a/spaceship/email.py
+++ b/spaceship/email.py
@@ -1,14 +1,14 @@
 import logging
 from flask import render_template
+import pendulum
 from sendgrid import SendGridAPIClient
 from sendgrid.helpers.mail import Mail
 
 from spaceship import app
+from spaceship.celery import celery
 from spaceship.models import Mission
 
 log = logging.getLogger('spaceship.email')
-
-from .celery import celery
 
 @celery.task
 def send(to_emails, subject, html_content, from_email='gaia@spaceshipearth.org'):
@@ -30,28 +30,33 @@ def send(to_emails, subject, html_content, from_email='gaia@spaceshipearth.org')
 def schedule_mission_emails(mission):
   """sets mission start/end emails to be sent at the correct time"""
   send_mission_start.apply_async(
-    args=(mission.id, mission.started_at),
+    args=(mission.id, mission.started_at.isoformat()),
     eta=mission.started_at,
     expires=mission.started_at.add(days=1),  # don't bother sending past a day late
   )
 
   send_mission_end.apply_async(
-    args=(mission.id, mission.end_time),
+    args=(mission.id, mission.end_time.isoformat()),
     eta=mission.end_time,
     expires=mission.end_time.add(days=1),    # don't bother sending past a day late
   )
 
 @celery.task
-def send_mission_start(mission_id, started_at):
+def send_mission_start(mission_id, planned_start_str):
   mission = Mission.query.get(mission_id)
-  if not (mission and mission.is_active):
+  planned_start = pendulum.parse(planned_start_str)
+
+  # mission should be active
+  if (not mission) or mission.is_deleted:
     log.warning(f'not sending mission start email for inactive mission {mission_id}')
     return
 
   # the start time has changed, so a different thing will actually
   # send the email
-  if mission.started_at != started_at:
-    log.warning(f'not sending mission start email for {mission} since start time has changed')
+  if mission.started_at != planned_start:
+    log.warning(
+      f"not sending mission start email for {mission} since start time has changed "\
+      f"({mission.started_at} from {planned_start})")
     return
 
   # if we got here, we should actually send an email
@@ -66,16 +71,20 @@ def send_mission_start(mission_id, started_at):
   )
 
 @celery.task
-def send_mission_end(mission_id, end_time):
+def send_mission_end(mission_id, planned_end_str):
   mission = Mission.query.get(mission_id)
+  planned_end = pendulum.parse(planned_end_str)
+
   if not (mission and mission.is_active):
     log.warning(f'not sending mission end email for inactive mission {mission_id}')
     return
 
   # the end time has changed, so a different thing will actually
   # send the email
-  if mission.end_time != end_time:
-    log.warning(f'not sending mission end email for {mission} since end time has changed')
+  if mission.end_time != planned_end:
+    log.warning(
+      f"not sending mission end email for {mission} since end time has changed "\
+      f"({mission.end_time} from {planned_end})")
     return
 
   # if we got here, we should actually send an email

--- a/spaceship/email.py
+++ b/spaceship/email.py
@@ -62,7 +62,9 @@ def send_mission_start(mission_id, planned_start_str):
   # if we got here, we should actually send an email
   emails = [m.email for m in mission.team.members]
   subject = 'Synchronize your watches, the mission begins!'
-  content = render_template('email_mission_start.html', mission=mission)
+
+  with app.app_context():
+    content = render_template('email_mission_start.html', mission=mission)
 
   send(
     to_emails=emails,
@@ -97,7 +99,12 @@ def send_mission_end(mission_id, planned_end_str):
   else:
     next_upcoming = None
 
-  content = render_template('email_mission_end.html', mission=mission, next_upcoming=next_upcoming)
+  with app.app_context():
+    content = render_template(
+      'email_mission_end.html',
+      mission=mission,
+      next_upcoming=next_upcoming,
+    )
 
   send(
     to_emails=emails,

--- a/spaceship/templates/compose_email.html
+++ b/spaceship/templates/compose_email.html
@@ -6,7 +6,7 @@
   <input type="text" placeholder="bob@example.com mary@example.com" class="form-control" id="emails">
 
 </div>
-<small class="text-muted"">Enter one or more emails separated by spaces.</small>
+<small class="text-muted">Enter one or more emails separated by spaces.</small>
 
 <div class="input-group mt-1 mb-2">
     <div class="input-group-prepend">

--- a/spaceship/templates/crew_growing_email.html
+++ b/spaceship/templates/crew_growing_email.html
@@ -2,4 +2,4 @@ Congrats,
 
 {{name}} has joined you crew! 
 
-<a href="{{url_for('crew', team_id=team_id)}}"">Visit your team page</a>
+<a href="{{url_for('crew', team_id=team_id)}}">Visit your team page</a>

--- a/spaceship/templates/email_mission_end.html
+++ b/spaceship/templates/email_mission_end.html
@@ -23,4 +23,3 @@ The United Earth Council will be in touch with them re: this matter, but feel fr
 </p>
 
 <p>© SpaceshipEarth</p>
-

--- a/spaceship/templates/email_mission_start.html
+++ b/spaceship/templates/email_mission_start.html
@@ -5,7 +5,7 @@
 
 <p>
 Our mission has now started.
-This mission, which will run for {{ mission.dureation_in_weeks }} weeks, is:
+This mission, which will run for {{ mission.duration_in_weeks }} weeks, is:
 </p>
 
 <div class="card" style="width: 18rem;">
@@ -16,6 +16,7 @@ This mission, which will run for {{ mission.dureation_in_weeks }} weeks, is:
     <p class="card-text">
     {{ goal.short_description }}
     </p>
+    {% endfor %}
   </div>
 </div>
 


### PR DESCRIPTION
this makes email sending for mission start and end actually work. there were two main problems:

* the planned start date came through as a string, so it was never `== mission.started_at` (which is a `pendulum` object). not sure why that is -- probably because we're using `JSON` serialization with celery? anyway, i now parse the planned start and end times into pendulum objects, so i can compare to the actual mission start/end times

* we couldn't render the email templates because we were outside of the app context. 