### PR TITLE
Center background earth image.

### DIFF
--- a/spaceship/static/spaceship.css
+++ b/spaceship/static/spaceship.css
@@ -59,7 +59,7 @@ main {
 }
 
 .splash-page {
-  background: #000 url(/static/earth.jpg) center bottom no-repeat;
+  background: #000 url(/static/earth.jpg) center center no-repeat;
   background-size: 100vw;
 }
 


### PR DESCRIPTION
This is a minor design tweak.  I think the earth in the background looks better centered like this.

Before:
<img width="414" alt="Screen Shot 2019-07-18 at 8 10 30 PM" src="https://user-images.githubusercontent.com/31038/61506789-286f0b80-a998-11e9-8a32-6790be10fbf0.png">

<img width="1116" alt="Screen Shot 2019-07-18 at 8 13 14 PM" src="https://user-images.githubusercontent.com/31038/61506913-8d2a6600-a998-11e9-9882-6708051fbae6.png">

After:
<img width="412" alt="Screen Shot 2019-07-18 at 8 10 38 PM" src="https://user-images.githubusercontent.com/31038/61506830-48063400-a998-11e9-93b5-857698182995.png">

<img width="1111" alt="Screen Shot 2019-07-18 at 8 13 01 PM" src="https://user-images.githubusercontent.com/31038/61506898-83086780-a998-11e9-9b4e-cbce29004838.png">
