### PR TITLE
avoid celery getting into a weird db state

### DIFF
--- a/spaceship/celery.py
+++ b/spaceship/celery.py
@@ -1,9 +1,24 @@
 
 from celery import Celery
 
-from . import app
+from spaceship import app
+from spaceship.db import db as sqlalchemy_db
+
 host, port, db = app.config['REDIS_HOST'], app.config['REDIS_PORT'], app.config['REDIS_DB']
 
 celery = Celery(app.name, broker=f"redis://{host}:{port}/{db}")
 celery.conf.task_serializer = 'json'
 celery.conf.always_eager = not app.config['USE_CELERY_WORKERS']
+
+class SqlAlchemyTask(celery.Task):
+    """An abstract Celery Task that ensures that the connection the the
+    database is closed on task completion"""
+    abstract = True
+
+    def after_return(self, status, retval, task_id, args, kwargs, einfo):
+        if einfo:
+            sqlalchemy_db.session.rollback()
+        else:
+            sqlalchemy_db.session.commit()
+
+        sqlalchemy_db.session.remove()

--- a/spaceship/celery.py
+++ b/spaceship/celery.py
@@ -11,11 +11,15 @@ celery.conf.task_serializer = 'json'
 celery.conf.always_eager = not app.config['USE_CELERY_WORKERS']
 
 class SqlAlchemyTask(celery.Task):
-    """An abstract Celery Task that ensures that the connection the the
+    """An abstract Celery Task that ensures that the connection to the
     database is closed on task completion"""
+
+    # this apparently keeps the task from being registered in some task
+    # database if instantiated?
     abstract = True
 
     def after_return(self, status, retval, task_id, args, kwargs, einfo):
+        """when the task is complete, auto-commit or auto-rollback the session"""
         if einfo:
             sqlalchemy_db.session.rollback()
         else:

--- a/spaceship/email.py
+++ b/spaceship/email.py
@@ -84,7 +84,7 @@ def send_mission_end(mission_id, planned_end_str):
   mission = Mission.query.get(mission_id)
   planned_end = pendulum.parse(planned_end_str)
 
-  if not (mission and mission.is_active):
+  if not mission or mission.is_deleted:
     log.warning(f'not sending mission end email for inactive mission {mission_id}')
     return
 

--- a/spaceship/email.py
+++ b/spaceship/email.py
@@ -6,7 +6,7 @@ from sendgrid import SendGridAPIClient
 from sendgrid.helpers.mail import Mail
 
 from spaceship import app
-from spaceship.celery import celery
+from spaceship.celery import celery, SqlAlchemyTask
 from spaceship.models import Mission
 
 log = logging.getLogger('spaceship.email')
@@ -48,7 +48,7 @@ def schedule_mission_emails(mission):
     expires=mission.end_time.add(days=1),    # don't bother sending past a day late
   )
 
-@celery.task
+@celery.task(base=SqlAlchemyTask)
 def send_mission_start(mission_id, planned_start_str):
   mission = Mission.query.get(mission_id)
   planned_start = pendulum.parse(planned_start_str)
@@ -79,7 +79,7 @@ def send_mission_start(mission_id, planned_start_str):
     html_content=content,
   )
 
-@celery.task
+@celery.task(base=SqlAlchemyTask)
 def send_mission_end(mission_id, planned_end_str):
   mission = Mission.query.get(mission_id)
   planned_end = pendulum.parse(planned_end_str)


### PR DESCRIPTION
been seeing errors like this:
```
_revalidate_connection "Can't reconnect until invalid " sqlalchemy.exc.StatementError: (sqlalchemy.exc.InvalidRequestError) Can't reconnect until invalid transaction is rolled back
```

and like this:
```
sqlalchemy.exc.InvalidRequestError: Can't reconnect until invalid transaction is rolled back
```

this happens if there's some error in a celery task. this breaks mysql
in that worker forever (because workers only initialize the DB once, at
startup).

we add a hook to auto-roll back the session if there's an error in the
task, or auto-commit it if there's no error, and then remove the session
no matter what at the end of the task. this allows our workers to
continue processing tasks even if something goes wrong with one of them.